### PR TITLE
replacing strsplit() due to MATLAB version issues

### DIFF
--- a/Core/tvm_matrixFromRegisterDatFile.m
+++ b/Core/tvm_matrixFromRegisterDatFile.m
@@ -1,10 +1,8 @@
 function matrix = tvm_matrixFromRegisterDatFile(registerDotDat)
 
 f = fopen(registerDotDat);
-text = fread(f, 'uint8=>char')';
+s=textscan(f,'%s');s=s{1};
 fclose(f);
-
-s = strsplit(text, '\n');
 
 matrix = zeros(4);
 
@@ -12,9 +10,9 @@ matrix = zeros(4);
 %voxelSize1 = s(2);
 %voxelSize2 = s(3);
 %voxelSize? = s(4);
-matrix(1, :) = sscanf(s{5}, '%f')';
-matrix(2, :) = sscanf(s{6}, '%f')';
-matrix(3, :) = sscanf(s{7}, '%f')';
-matrix(4, :) = sscanf(s{8}, '%f')';
+matrix(1, :) = cellfun(@str2double,s(5:8))';
+matrix(2, :) = cellfun(@str2double,s(9:12))';
+matrix(3, :) = cellfun(@str2double,s(13:16))';
+matrix(4, :) = cellfun(@str2double,s(17:20))';
 
 end %end function


### PR DESCRIPTION
using textscan instead, which in the end requires a different matrix
setup